### PR TITLE
doxity init bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,15 @@
     "eslint-plugin-react": "^6.4.1"
   },
   "dependencies": {
+    "fs-extra": "^5.0.0",
     "glob": "^7.1.1",
     "keccakjs": "^0.2.1",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "request": "^2.79.0",
     "rimraf": "^2.5.4",
-    "tar.gz": "^1.0.5",
+    "request-promise": "^4.2.2",
+    "targz": "^1.0.1",
     "toml": "^2.3.0",
     "tomlify-j0.4": "^1.0.1",
     "truffle-compile": "git://github.com/digixglobal/truffle-compile.git#f2cef1520aafeb82c9e87c2c75314281b4ca549b",

--- a/src/init.js
+++ b/src/init.js
@@ -29,7 +29,6 @@ export default function (args) {
       });
 
       ws.on('finish', function(){
-        console.log('finished writing tar file')
         targz.decompress({
           src: tarFilePath,
           dest: tmpTarget

--- a/src/init.js
+++ b/src/init.js
@@ -1,34 +1,58 @@
-import fs from 'fs';
 import childProcess from 'child_process';
-import request from 'request';
+import request from 'request-promise';
 import path from 'path';
-import targz from 'tar.gz';
+import targz from 'targz'
+import fs from 'fs-extra'
 
 import { clearDirectory } from './helpers';
 
 import { DOXITYRC_FILE } from './constants';
 
 export default function (args) {
+ 
   const { source, target } = args;
-  // TODO check folder exists...
+
   const absoluteTarget = `${process.env.PWD}/${target}`;
+  const tarFilePath = `${process.env.PWD}/tarFile.tar.gz`;
   const tmpTarget = path.resolve(`${process.env.PWD}/${target}/../doxity-tmp-${new Date()}`);
+
   // clear the target dir
   clearDirectory(absoluteTarget)
   .then(() => {
-    // clone the repo
-    process.stdout.write(`Getting ${source}...\n`);
-    // pipe package to thingy.
+
     return new Promise((resolve) => {
-      request.get(source)
-      .pipe(targz().createWriteStream(tmpTarget))
-      .on('finish', resolve);
+      // download the tar
+      let ws = fs.createWriteStream(tarFilePath)
+
+      ws.on('open', function() {
+        request(source).pipe(ws)
+      });
+
+      ws.on('finish', function(){
+        console.log('finished writing tar file')
+        targz.decompress({
+          src: tarFilePath,
+          dest: tmpTarget
+        }, function(err){
+            if(err) {
+                console.log(err);
+            } else {
+                // delete the tar file
+                fs.remove(tarFilePath)
+                  .then(() => {
+                    resolve()
+                  })
+            }
+        });
+      })
     });
   })
+
+
   // rename the downloaded folder to doxity
   .then(() => {
     fs.renameSync(`${tmpTarget}/${fs.readdirSync(tmpTarget)[0]}`, absoluteTarget);
-    fs.rmdirSync(tmpTarget);
+    return fs.remove(tmpTarget)
   })
   .then(() => {
     // fancy spinner
@@ -56,5 +80,5 @@ export default function (args) {
       process.stdout.write('Doxity is initialized! Now run `doxity build`\n');
       process.exit();
     });
-  });
+  })
 }


### PR DESCRIPTION
deprecated tar.gz package was causing an issue
(https://github.com/DigixGlobal/doxity/issues/25) where the init script
would try to copy the gatsby template project over to the destination
dir before the tar was completely unpackaged. Fixed the issue by using
targz module instead and splitting out the download/untar operations.